### PR TITLE
Small improvemenst with backward compitability

### DIFF
--- a/src/wolfmq_mgr.erl
+++ b/src/wolfmq_mgr.erl
@@ -74,14 +74,14 @@ add_to_queue(QueueId, Tasks) when is_list(Tasks) ->
     [{QueueId, EtsId, HandlerPid}] = ets:lookup(wolfmq_queues, QueueId),
     List = [{Now, Task} || Task <- Tasks],
     true = ets:insert(EtsId, List),
-    force_queue_processing(EtsId, HandlerPid),
+    force_queue_processing(EtsId, HandlerPid, erlang:length(List)),
     ok;
 add_to_queue(QueueId, Task) ->
     Now = erlang_system_time(micro_seconds),
     [{QueueId, EtsId, HandlerPid}] = ets:lookup(wolfmq_queues, QueueId),
     Tuple = {Now, Task},
     true = ets:insert(EtsId, Tuple),
-    force_queue_processing(EtsId, HandlerPid),
+    force_queue_processing(EtsId, HandlerPid, 1),
     ok.
 
 %% erlang:system_time fallback functions
@@ -121,11 +121,17 @@ integer_time_unit(I) when is_integer(I), I > 0 -> I;
 integer_time_unit(BadRes) -> erlang:error(bad_time_unit, [BadRes]).
 
 
-force_queue_processing(EtsId, HandlerPid) ->
-    case ets:info(EtsId, size) of
-        N when N < 2 ->
-            HandlerPid ! process_queue,
-            ok;
+force_queue_processing(EtsId, HandlerPid, JobListSize) ->
+    TabInfo = ets:info(EtsId),
+    case proplists:get_value(size, TabInfo) of
+        JobsWaitProcessing when is_integer(JobsWaitProcessing) ->
+            force((JobsWaitProcessing - JobListSize), HandlerPid);
         _ ->
             ok
     end.
+
+force(Diff, HandlerPid) when Diff > 2 ->
+    HandlerPid ! process_queue,
+    ok;
+force(_, _) ->
+    ok.


### PR DESCRIPTION
1) Forcing queue processing for just initiated queues or empty queues;
2) Moved to config default processing latency /wolfmq/latency;
3) Saved backward compitability for old erlang vsn.